### PR TITLE
fix: Handle lowercase letters in languages

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -78,10 +78,10 @@ exports.addDefaults = /** @type Parser */ parser => {
     parser.addHandler("language", /\bRUS\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bNL\b/, { type: "lowercase" });
     parser.addHandler("language", /\bFLEMISH\b/, { type: "lowercase" });
-    parser.addHandler("language", /\bGERMAN\b/i, { type: "lowercase" });
+    parser.addHandler("language", /\bGERMAN\b/, { type: "lowercase" });
     parser.addHandler("language", /\bDUBBED\b/, { type: "lowercase" });
-    parser.addHandler("language", /\bITA(?:LIAN)?\b/i, { type: "lowercase" });
-    parser.addHandler("language", /\bFR(?:ENCH)?\b/i, { type: "lowercase" });
+    parser.addHandler("language", /\b(ITA(?:LIAN)?|iTALiAN)\b/, { type: "lowercase" });
+    parser.addHandler("language", /\bFR(?:ENCH)?\b/, { type: "lowercase" });
     parser.addHandler("language", /\bTruefrench|VF(?:[FI])\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bVOST(?:(?:F(?:R)?)|A)?|SUBFRENCH\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bMULTi(?:Lang|-VF2)?\b/i, { type: "lowercase" });

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -78,10 +78,10 @@ exports.addDefaults = /** @type Parser */ parser => {
     parser.addHandler("language", /\bRUS\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bNL\b/, { type: "lowercase" });
     parser.addHandler("language", /\bFLEMISH\b/, { type: "lowercase" });
-    parser.addHandler("language", /\bGERMAN\b/, { type: "lowercase" });
+    parser.addHandler("language", /\bGERMAN\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bDUBBED\b/, { type: "lowercase" });
-    parser.addHandler("language", /\bITA(?:LIAN)?\b/, { type: "lowercase" });
-    parser.addHandler("language", /\bFR(?:ENCH)?\b/, { type: "lowercase" });
+    parser.addHandler("language", /\bITA(?:LIAN)?\b/i, { type: "lowercase" });
+    parser.addHandler("language", /\bFR(?:ENCH)?\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bTruefrench|VF(?:[FI])\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bVOST(?:(?:F(?:R)?)|A)?|SUBFRENCH\b/i, { type: "lowercase" });
     parser.addHandler("language", /\bMULTi(?:Lang|-VF2)?\b/i, { type: "lowercase" });


### PR DESCRIPTION
It's fairly common to see torrents with the language written as `iTALiAN`, with this fix the regex will match it.