### PR TITLE
fix: added season handler for season packs

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -77,6 +77,7 @@ exports.addDefaults = /** @type Parser */ parser => {
     parser.addHandler("group", /- ?([^\-. ]+)$/);
 
     // Season
+    parser.addHandler("season", /([0-9]{1,2})xall/i, { type: "integer" });
     parser.addHandler("season", /S([0-9]{1,2}) ?E[0-9]{1,2}/i, { type: "integer" });
     parser.addHandler("season", /([0-9]{1,2})x[0-9]{1,2}/, { type: "integer" });
     parser.addHandler("season", /(?:Saison|Season)[. _-]?([0-9]{1,2})/i, { type: "integer" });

--- a/test/season.js
+++ b/test/season.js
@@ -31,4 +31,10 @@ describe("Parsing season", () => {
 
         expect(parse(releaseName)).to.deep.include({ season: 5 });
     });
+
+    it("should detect season packs", () => {
+        const releaseName = "My Adventures with Superman - 1xAll - Complete (Season 720p .mkv WEB)";
+
+        expect(parse(releaseName)).to.deep.include({ season: 1 });
+    });
 });


### PR DESCRIPTION
season releases are not properly handled. 

`My Adventures with Superman - 1xAll - Complete (Season 720p .mkv WEB)`
yields `Season 72`

Thanks to the power of `handlers` + `regex` we can address this easily

- added season handler  for season packs
- added tests

fixes #17 