### PR TITLE
Prevent matching to episode if 'ep' is followed by a year

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -85,7 +85,7 @@ exports.addDefaults = /** @type Parser */ parser => {
     // Episode
     parser.addHandler("episode", /S[0-9]{1,2} ?E([0-9]{1,2})/i, { type: "integer" });
     parser.addHandler("episode", /[0-9]{1,2}x([0-9]{1,2})/, { type: "integer" });
-    parser.addHandler("episode", /[ée]p(?:isode)?[. _-]?([0-9]{1,3})/i, { type: "integer" });
+    parser.addHandler("episode", /[ée]p(?:isode)?[. _-]?([0-9]{1,3})(?![0-9])/i, { type: "integer" });
 
     // Language
     parser.addHandler("language", /\bRUS\b/i, { type: "lowercase" });

--- a/test/episode.js
+++ b/test/episode.js
@@ -37,4 +37,11 @@ describe("Parsing episode", () => {
 
         expect(parse(releaseName)).to.deep.include({ episode: 14 });
     });
+
+    it("should not consider the string 'ep' as an episode indicator if it is followed by a year", () => {
+        const releaseName = "The Keep 1983 1080p Blu-ray AVC DTS-HD MA 2.0-FULLBRUTALiTY";
+
+        expect(parse(releaseName)).to.not.deep.include({ episode: 198 });
+        expect(parse(releaseName)).to.deep.include({ title: "The Keep" });
+    });
 });


### PR DESCRIPTION
PR to address https://github.com/clement-escolano/parse-torrent-title/issues/19. This updates the episode regex so that it fails if the set of numbers following the `ep` string is 4 digits (i.e. likely a year). In the current logic it passes if it has at least 1-3 digits, but does not evaluate whether there are additional digits after the 3rd one, so the string:
```
The Keep 1983 1080p Blu-ray AVC DTS-HD MA 2.0-FULLBRUTALiTY
```
Gets evaluated with a title of `The Ke` and an episode number of `198`